### PR TITLE
Add pipeline for deploying to pypi

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,6 +59,6 @@ jobs:
     - uses: pypa/gh-action-pypi-publish@v1.5.0
       with:
         user: __token__
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.pypi_token }}
         # uncomment for testing
         # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,11 +1,7 @@
 name: Build and upload to PyPI
 
 on:
-  # uncomment to build on push (useful for testing)
-  # push:
-  release:
-    types:
-      - published
+  push:
 
 jobs:
   make_sdist:
@@ -25,6 +21,7 @@ jobs:
       run: CYTHONIZE=0 python -m build --sdist
     - uses: actions/upload-artifact@v3
       with:
+        name: fatfs-dist
         path: dist/*.tar.gz
     - name: Check metadata
       run: twine check dist/*
@@ -46,15 +43,17 @@ jobs:
           CIBW_ENVIRONMENT_PASS_LINUX: CYTHONIZE
       - uses: actions/upload-artifact@v3
         with:
+          name: fatfs-dist
           path: wheelhouse/*.whl
 
-  upload_all:
+  upload_to_pypi:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: artifact
+        name: fatfs-dist
         path: dist
     - uses: pypa/gh-action-pypi-publish@v1.5.0
       with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,64 @@
+name: Build and upload to PyPI
+
+on:
+  # uncomment to build on push (useful for testing)
+  # push:
+  release:
+    types:
+      - published
+
+jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
+    - name: Install deps
+      run: python -m pip install build twine cython
+    - name: Generate *.c from *.pyx
+      run: python -m cython -3 **/*.pyx
+    - name: Build SDist
+      run: CYTHONIZE=0 python -m build --sdist
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
+    - name: Check metadata
+      run: twine check dist/*
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.13.0
+        env:
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_BEFORE_BUILD: pip install cython
+          CIBW_ENVIRONMENT: CYTHONIZE=1
+          CIBW_ENVIRONMENT_PASS_LINUX: CYTHONIZE
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@v1.5.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        # uncomment for testing
+        # repository_url: https://test.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,12 @@ extensions = [
     Extension("wrapper", ["fatfs/wrapper.pyx", "fatfs/diskiocheck.c", "foreign/fatfs/source/ff.c", "foreign/fatfs/source/ffsystem.c", "foreign/fatfs/source/ffunicode.c"], include_dirs=["foreign/fatfs/source"]),
 ]
 
-CYTHONIZE = bool(int(os.getenv("CYTHONIZE", 0))) and cythonize is not None
+cythonize_env = bool(int(os.getenv("CYTHONIZE", 0)))
+
+if cythonize_env and cythonize_env is None:
+    raise Exception("Cython needs to be installed for CYTHONIZE=1")
+
+CYTHONIZE = cythonize_env and cythonize is not None
 
 if CYTHONIZE:
     compiler_directives = {"language_level": 3, "embedsignature": True}
@@ -46,7 +51,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='fatfs',
-    version="0.0.6",
+    version="0.0.7",
     author="Ladislav Laska",
     author_email="krakonos@krakonos.org",
     description="A wrapper around ChaN's FatFS library for FAT filesystem manipulation.",
@@ -57,9 +62,9 @@ setup(
     url="https://github.com/krakonos/fatfs-python",
     #packages=['pyfatfs', 'pyfatfs.tests'],
     packages=find_packages(),
-    install_requires=['cython'],
+    setup_requires=['cython'],
     zip_safe=False,
-    python_requires='>=3.6', #TODO: Actual version?
+    python_requires='>=3.8',
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This adds an Action that creates an `sdist` (including generated `*.c` files) and `wheel` packages for multiple platforms. Generated files are published on PyPI The action is executed on Github release. 

Package resulting package published on `test.pypi.org` can be found [here](https://test.pypi.org/project/fatfs/).

For the Action to work, it is necessary to create a new repository secret `pypi_password` that contains PyPI access token.